### PR TITLE
Invalid Token - Prompt For New Token

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "build": "webpack --mode=production",
-    "postinstall": "npm run build > /dev/null && find ./unpacked-extension -type f -not -name 'manifest.json' -delete",
+    "postinstall": "yarn build > /dev/null && find ./unpacked-extension -type f -not -name 'manifest.json' -delete",
     "start": "webpack --watch --mode=development",
     "lint": "eslint ./src/**/*.js"
   },

--- a/src/Components.js
+++ b/src/Components.js
@@ -1,0 +1,19 @@
+import React from 'react'
+
+export const TakoLogo = ({ style, ...rest }) => (
+    <div
+      {...rest}
+      style={{
+        width: 60,
+        height: 60,
+        backgroundImage: `url(${chrome.runtime.getURL('tako.svg')})`,
+        backgroundSize: '90%',
+        backgroundRepeat: 'no-repeat',
+        backgroundPosition: 'center',
+        backgroundColor: '#fff',
+        borderRadius: '50%',
+        boxShadow: '0 0 0 5px white',
+        ...style,
+      }}
+    />
+  )

--- a/src/GlobalErrorBoundary.js
+++ b/src/GlobalErrorBoundary.js
@@ -3,6 +3,7 @@ import React, { Fragment } from 'react'
 import { MOUNT_SELECTOR } from '@/constants'
 import PrependPortal from '@/PrependPortal'
 import { removeToken } from '@/utils'
+import { TakoLogo } from '@/Components'
 
 const ErrorReport = ({ error, children }) => {
   const [isExpanded, setIsExpanded] = React.useState(false)
@@ -10,8 +11,16 @@ const ErrorReport = ({ error, children }) => {
   return (
     <Fragment>
       <div className="bg-red-light text-red p-2 d-flex flex-items-center">
+        <TakoLogo
+          style={{
+            height: 30,
+            width: 30,
+            float: 'left',
+            margin: 'auto 1rem auto 0',
+          }}
+        />
         <div className="flex-auto">
-          Something went wrong while tring to load {process.env.DISPLAY_NAME}
+          Something went wrong while trying to load {process.env.DISPLAY_NAME}
         </div>
         <button
           className="btn btn-sm"
@@ -32,8 +41,6 @@ const ErrorReport = ({ error, children }) => {
       <div
         hidden={!isExpanded}
         className="text-gray-dark p-2 bg-red-light border-top border-black-fade"
-        // In testing, some errors would flow off screen, allowing `overflowX: scroll` fixed this
-        style={{ overflowX: 'scroll' }}
       >
         <pre
           css={{
@@ -42,6 +49,21 @@ const ErrorReport = ({ error, children }) => {
               fontSize: 14,
               lineHeight: '30px',
             },
+            // Persists vertical scrollbar on OSX if overflowY
+            '::-webkit-scrollbar': {
+              '-webkit-appearance': 'none',
+              width: '7px',
+            },
+            // Persists vertical scrollbar on OSX if overflowY
+            '::-webkit-scrollbar-thumb': {
+              borderRadius: '4px',
+              backgroundColor: 'rgba(0, 0, 0, .5)',
+              boxShadow: '0 0 1px rgba(255, 255, 255, .5)',
+            },
+            overflowX: 'auto',
+            whiteSpace: 'pre-wrap',
+            wordWrap: 'break-word',
+            maxHeight: '120px',
           }}
         >
           {/**

--- a/src/Root.js
+++ b/src/Root.js
@@ -4,7 +4,7 @@ import { MOUNT_SELECTOR } from '@/constants'
 import { useStore } from '@/storage'
 import App from '@/App'
 import PrependPortal from '@/PrependPortal'
-
+import { TakoLogo } from '@/Components'
 import { PromptForNewToken } from '@/GlobalErrorBoundary'
 
 const AskForToken = () => {
@@ -13,19 +13,7 @@ const AskForToken = () => {
 
   return (
     <div className="bg-yellow-light text-gray-dark p-3 d-flex flex-items-center lh-default">
-      <div
-        style={{
-          width: 60,
-          height: 60,
-          backgroundImage: `url(${chrome.runtime.getURL('tako.svg')})`,
-          backgroundSize: '90%',
-          backgroundRepeat: 'no-repeat',
-          backgroundPosition: 'center',
-          backgroundColor: '#fff',
-          borderRadius: '50%',
-          boxShadow: '0 0 0 5px white',
-        }}
-      />
+      <TakoLogo />
       <div className="flex-auto pl-3">
         <div>
           {process.env.DISPLAY_NAME} needs a <b>personal access token</b> to

--- a/src/Root.js
+++ b/src/Root.js
@@ -5,6 +5,8 @@ import { useStore } from '@/storage'
 import App from '@/App'
 import PrependPortal from '@/PrependPortal'
 
+import { PromptForNewToken } from '@/GlobalErrorBoundary'
+
 const AskForToken = () => {
   const [token, setToken] = React.useState('')
   const validToken = /[\da-f]{40}/.test(token)
@@ -71,12 +73,18 @@ const AskForToken = () => {
 }
 
 const Root = () => {
-  const token = useStore(state => state.token)
+  const { token, requestError } = useStore(state => state)
+  const unauthorizedError = requestError && Number(requestError.status) === 401
 
   return (
     <PrependPortal targetSelector={MOUNT_SELECTOR}>
-      {!token && <AskForToken />}
-      {token && <App />}
+      {token && unauthorizedError && (
+        <PromptForNewToken
+          error={`${requestError.status}: ${requestError.statusText}\r\n\r\nToken is invalid!  Use the 'Prompt For New Token' button below to update your token.`}
+        />
+      )}
+      {!token && !unauthorizedError && <AskForToken />}
+      {token && !unauthorizedError && <App />}
     </PrependPortal>
   )
 }

--- a/src/api.js
+++ b/src/api.js
@@ -10,20 +10,37 @@ const limiter = new Bottleneck({
   maxConcurrent: MAX_REQUESTS,
 })
 
-const githubFetch = (fragment, { importance, ...options } = {}) =>
-  fetch(`https://api.github.com/${fragment}`, {
+const githubFetch = (fragment, { importance, ...options } = {}) => {
+  const { token, setRequestError } = getState()
+
+  return fetch(`https://api.github.com/${fragment}`, {
     ...options,
     importance,
     headers: {
-      Authorization: `token ${getState().token}`,
+      Authorization: `token ${token}`,
     },
   }).then(response => {
     if (response.status < 200 || response.status > 299) {
+      const { status, statusText } = response;
+      
+      setRequestError({ status, statusText })
+
+      // A user may have manually removed token from GitHub account,
+      // if they have, this should prompt them for a new token
+      if (response.status === 401 && token) {
+          throw new Error(
+            `${response.status}: ${response.statusText}\r\n\r\nToken is invalid!  Use the 'Prompt For New Token' button below to update your token.`
+          )
+      } 
+
       throw new Error(`${response.status}: ${response.statusText}`)
     }
 
     return response
+  }).catch(error => {
+    throw error
   })
+}
 
 export const getNode = (
   type,

--- a/src/api.js
+++ b/src/api.js
@@ -20,20 +20,11 @@ const githubFetch = (fragment, { importance, ...options } = {}) => {
       Authorization: `token ${token}`,
     },
   }).then(response => {
-    if (response.status < 200 || response.status > 299) {
-      const { status, statusText } = response;
-      
+    const { status, statusText } = response;
+
+    if (status < 200 || status > 299) {
       setRequestError({ status, statusText })
-
-      // A user may have manually removed token from GitHub account,
-      // if they have, this should prompt them for a new token
-      if (response.status === 401 && token) {
-          throw new Error(
-            `${response.status}: ${response.statusText}\r\n\r\nToken is invalid!  Use the 'Prompt For New Token' button below to update your token.`
-          )
-      } 
-
-      throw new Error(`${response.status}: ${response.statusText}`)
+      throw new Error(`${status}: ${statusText}`)
     }
 
     return response

--- a/src/storage.js
+++ b/src/storage.js
@@ -19,6 +19,15 @@ const [useStore, api] = createStore((set, get) => {
     token: null,
     expandedNodes: {},
 
+    requestError: null,
+
+    setRequestError: err => {
+      setState(state => ({
+        ...state,
+        requestError: err,
+      }))
+    },
+
     setPath: path =>
       setState(state => {
         state.repoDetails.path = path

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,7 @@
 import arraySort from 'array-sort'
 
 import { SORT_ORDER } from '@/constants'
+import { setState } from '@/storage'
 
 export const sortContents = contents =>
   arraySort(
@@ -36,3 +37,15 @@ export const betterAtob = str =>
       .map(c => `%${`00${c.charCodeAt(0).toString(16)}`.slice(-2)}`)
       .join('')
   )
+
+export const removeToken = () =>
+  new Promise((resolve, reject) => {
+    chrome.storage.sync.remove('token', err => {
+      if (err) {
+        return reject(err)
+      }
+
+      setState(state => ({ ...state, token: undefined }))
+      return resolve()
+    })
+  })


### PR DESCRIPTION
Prompt for new token when 401 is encountered.

Resolves issue #14 

Allows user to request a new token if the existing token becomes invalid for whatever reason (ie: user manually removing a token from their account, etc..)

**Demo:** [mp4 version](https://i.imgur.com/gYqrphu.mp4)

![gYqrphu (1)](https://user-images.githubusercontent.com/21092343/78953563-df6b6400-7a9e-11ea-838c-7917af15bda3.gif)

Also adds the Tako logo to error boundary:

![image](https://user-images.githubusercontent.com/21092343/78977438-c33ae780-7add-11ea-8763-a89697b2c3f0.png)
