### PR TITLE
Don't hijack ctrl/cmd + click on files

### DIFF
--- a/src/components/Node.js
+++ b/src/components/Node.js
@@ -18,6 +18,26 @@ import Listing from '@/components/Listing'
 import Placeholder from '@/components/Placeholder'
 import { FolderIcon, FileIcon, ChevronIcon } from '@/components/icons'
 
+const maybeHijackClick = event => {
+  // The macOS "command" key
+  const macosCmdKey =
+    window.navigator.platform.indexOf('Mac') > -1 && event.nativeEvent.metaKey
+
+  if (
+    macosCmdKey ||
+    event.nativeEvent.ctrlKey ||
+    event.nativeEvent.altKey ||
+    event.nativeEvent.which === 2
+  ) {
+    // stop event from bubbling up, where it would otherwise cause expansion or preview
+    event.stopPropagation()
+  } else {
+    // this is the default case, where we
+    // prevent browser navigation so we can handle the click further up
+    event.preventDefault()
+  }
+}
+
 const Node = ({ type, name, path, parentCommitmessage, level }) => {
   const { user, repo, branch } = useStore(state => state.repoDetails)
   const { status: contentStatus } = useQueryState([
@@ -122,23 +142,7 @@ const Node = ({ type, name, path, parentCommitmessage, level }) => {
             <a
               title={name}
               href={`https://github.com/${user}/${repo}/blob/${branch}/${path}`}
-              onClick={event => {
-                // The macOS "command" key
-                const macosCmdKey =
-                  window.navigator.platform.indexOf('Mac') > -1 &&
-                  event.nativeEvent.metaKey
-
-                if (
-                  macosCmdKey ||
-                  event.nativeEvent.ctrlKey ||
-                  // middle click
-                  event.nativeEvent.which === 2
-                ) {
-                  event.stopPropagation()
-                } else {
-                  event.preventDefault()
-                }
-              }}
+              onClick={maybeHijackClick}
             >
               {name}
             </a>

--- a/src/components/Node.js
+++ b/src/components/Node.js
@@ -63,10 +63,7 @@ const Node = ({ type, name, path, parentCommitmessage, level }) => {
           }
         )
       } else {
-        const fileExtension = path
-          .split('.')
-          .slice(-1)[0]
-          .toLowerCase()
+        const fileExtension = path.split('.').slice(-1)[0].toLowerCase()
 
         if (fileExtension === 'md') {
           prefetchQuery(
@@ -126,7 +123,19 @@ const Node = ({ type, name, path, parentCommitmessage, level }) => {
               title={name}
               href={`https://github.com/${user}/${repo}/blob/${branch}/${path}`}
               onClick={event => {
-                if (event.nativeEvent.which !== 2) {
+                // The macOS "command" key
+                const macosCmdKey =
+                  window.navigator.platform.indexOf('Mac') > -1 &&
+                  event.nativeEvent.metaKey
+
+                if (
+                  macosCmdKey ||
+                  event.nativeEvent.ctrlKey ||
+                  // middle click
+                  event.nativeEvent.which === 2
+                ) {
+                  event.stopPropagation()
+                } else {
                   event.preventDefault()
                 }
               }}


### PR DESCRIPTION
As stated here: https://github.com/brumm/tako/issues/3#issuecomment-629458458

> Another type of click that should be detected in addition to middle clicks is cmd + click on macOS and ctrl + click on other platforms. All major browsers (as far as I know) support opening a link in a new tab when you ctrl/cmd + click them.

@brumm Maybe we should exclude alt + clicks as well, because at least on Chrome on macOS, there is a special handling for that (downloading the webpage).