### PR TITLE
Add submodule nodes functionality

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -52,12 +52,15 @@ export const getNode = (
     .then(response => response.json())
     .then(contents => {
       if (Array.isArray(contents)) {
-        return sortContents(contents).map(({ path, name, type, sha }) => ({
-          path,
-          name,
-          type,
-          sha,
-        }))
+        return sortContents(contents).map(
+          ({ path, name, type, sha, html_url }) => ({
+            path,
+            name,
+            type,
+            sha,
+            html_url,
+          })
+        )
       }
 
       return null

--- a/src/components/Node.js
+++ b/src/components/Node.js
@@ -40,7 +40,7 @@ const maybeHijackClick = event => {
   }
 }
 
-const Node = ({ type, name, path, parentCommitmessage, level }) => {
+const Node = ({ type, name, path, parentCommitmessage, level, html_url }) => {
   const { user, repo, branch } = useStore(state => state.repoDetails)
   const isExpanded = useStore(state => state.expandedNodes[path] === true)
   const toggleExpandNode = useStore(state => state.toggleExpandNode)
@@ -182,7 +182,7 @@ const Node = ({ type, name, path, parentCommitmessage, level }) => {
             <a
               title={name}
               className="link-gray-dark"
-              href={`https://github.com/${user}/${repo}/blob/${branch}/${path}`}
+              href={html_url}
               onClick={maybeHijackClick}
             >
               {name}

--- a/src/components/Node.js
+++ b/src/components/Node.js
@@ -17,7 +17,12 @@ import { markAsPrefetch } from '@/utils'
 import { Row, Cell, Truncateable } from '@/components/styled'
 import Listing from '@/components/Listing'
 import Placeholder from '@/components/Placeholder'
-import { FolderIcon, FileIcon, ChevronIcon } from '@/components/icons'
+import {
+  FolderIcon,
+  FileIcon,
+  ChevronIcon,
+  SubmoduleIcon,
+} from '@/components/icons'
 
 const maybeHijackClick = event => {
   // The macOS "command" key
@@ -49,6 +54,7 @@ const Node = ({ type, name, path, parentCommitmessage, level, html_url }) => {
   const hasNoSelectedFilePath = selectedFilePath === null
 
   const isSelected = path === selectedFilePath
+  const isSubmodule = type === 'submodule'
   const isFolder = type === 'dir'
 
   const childListingObserver = React.useMemo(
@@ -65,23 +71,40 @@ const Node = ({ type, name, path, parentCommitmessage, level, html_url }) => {
     ({ isLoading }) => isLoading
   )
 
-  let typeIcon = isFolder ? (
-    <FolderIcon
-      style={{
-        color: 'var(--color-files-explorer-icon)',
-        position: 'relative',
-        top: 1,
-      }}
-    />
-  ) : (
-    <FileIcon
-      style={{
-        color: 'var(--color-text-tertiary)',
-        position: 'relative',
-        top: 1,
-      }}
-    />
-  )
+  let typeIcon = undefined
+
+  if (isFolder) {
+    typeIcon = (
+      <FolderIcon
+        style={{
+          color: 'var(--color-files-explorer-icon)',
+          position: 'relative',
+          top: 1,
+        }}
+      />
+    )
+  } else if (isSubmodule) {
+    typeIcon = (
+      <SubmoduleIcon
+        style={{
+          color: 'var(--color-files-explorer-icon)',
+          position: 'relative',
+          top: 1,
+        }}
+      />
+    )
+  } else {
+    typeIcon = (
+      <FileIcon
+        style={{
+          color: 'var(--color-text-tertiary)',
+          position: 'relative',
+          top: 1,
+        }}
+      />
+    )
+  }
+
   typeIcon =
     isLoadingContents && isExpanded ? (
       <Spinner size="16px" color="var(--color-files-explorer-icon)" />
@@ -151,7 +174,7 @@ const Node = ({ type, name, path, parentCommitmessage, level, html_url }) => {
             event.stopPropagation()
             if (isFolder) {
               toggleExpandNode(path)
-            } else {
+            } else if (!isSubmodule) {
               setSelectedFilePath(path)
             }
           }}
@@ -183,7 +206,12 @@ const Node = ({ type, name, path, parentCommitmessage, level, html_url }) => {
               title={name}
               className="link-gray-dark"
               href={html_url}
-              onClick={maybeHijackClick}
+              target={isSubmodule ? '_blank' : undefined}
+              onClick={e => {
+                if (!isSubmodule) {
+                  maybeHijackClick(e)
+                }
+              }}
             >
               {name}
             </a>

--- a/src/components/icons.js
+++ b/src/components/icons.js
@@ -18,6 +18,24 @@ export const FolderIcon = props => (
   </svg>
 )
 
+export const SubmoduleIcon = props => (
+  <svg
+    aria-label="Submodule"
+    className="octicon octicon-file-submodule"
+    viewBox="0 0 16 16"
+    version="1.1"
+    width="16"
+    height="16"
+    role="img"
+    {...props}
+  >
+    <path
+      fillRule="evenodd"
+      d="M0 2.75C0 1.784.784 1 1.75 1H5c.55 0 1.07.26 1.4.7l.9 1.2a.25.25 0 00.2.1h6.75c.966 0 1.75.784 1.75 1.75v8.5A1.75 1.75 0 0114.25 15H1.75A1.75 1.75 0 010 13.25V2.75zm9.42 9.36l2.883-2.677a.25.25 0 000-.366L9.42 6.39a.25.25 0 00-.42.183V8.5H4.75a.75.75 0 100 1.5H9v1.927c0 .218.26.331.42.183z"
+    ></path>
+  </svg>
+)
+
 export const FileIcon = props => (
   <svg
     height="16"

--- a/src/constants.js
+++ b/src/constants.js
@@ -5,7 +5,7 @@ export const APP_CONTAINER_SELECTOR = '.tako-container'
 export const TOOLBAR_MOUNT_SELECTOR =
   '.file-navigation ~ div ul.list-style-none.d-flex'
 
-export const SORT_ORDER = ['dir', 'file']
+export const SORT_ORDER = ['dir', 'file', 'submodule']
 
 export const INDENT_SIZE = 24
 


### PR DESCRIPTION
This PR closes #68, it makes Tako work with submodules.

- Submodules use the correct icon
- Submodule nodes stop being treated as files, which couldn't be  previewed
- When clicking on a submodule, it's opened on a new tab

### Before

https://user-images.githubusercontent.com/25667102/187484805-038b2687-0dcb-465e-818d-fa39fbf47c48.mp4


### After

https://user-images.githubusercontent.com/25667102/187484819-dd62558f-eb18-44fc-94df-662cdf739028.mp4



