### PR TITLE
Avoid running on Github's documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,9 @@
         "matches": [
           "*://*.github.com/*"
         ],
+        "exclude_matches": [
+          "*://docs.github.com/*"
+        ],
         "js": [
           "content-script.js"
         ],


### PR DESCRIPTION
For some reason, on Firefox (couldn't replicate it on chrome), Tako interferes on the code snippets of gh's documentation!

Every snippet gets replaced by a series of `[object Object]` 

![image](https://user-images.githubusercontent.com/25667102/189770943-28b1f1ee-ac58-42c9-b204-4e3ad5d93c19.png)

This PR removes `docs.github.com` from the websites the extension runs in

![image](https://user-images.githubusercontent.com/25667102/189771023-bd0afd09-b68d-4cc8-9a9a-8dff230ffbc3.png)
