### PR TITLE
force remount Tako on removal

### DIFF
--- a/src/content.tsx
+++ b/src/content.tsx
@@ -15,7 +15,6 @@ const start = async () => {
   }
 
   onElementRemoval('.tako', () => {
-    console.log('remount tako')
     start()
   })
   const { token } = await storage.sync.get('token')

--- a/src/content.tsx
+++ b/src/content.tsx
@@ -7,9 +7,17 @@ import { storage } from 'webextension-polyfill'
 import { Tako, TakoProvider } from './components/Tako'
 import { TokenPrompt } from './components/TokenPrompt'
 import { useStore } from './store'
-import { waitForElement } from './waitForElement'
+import { onElementRemoval, waitForElement } from './waitForElement'
 
 const start = async () => {
+  if (!isRepoRoot() || !isRepoTree()) {
+    return
+  }
+
+  onElementRemoval('.tako', () => {
+    console.log('remount tako')
+    start()
+  })
   const { token } = await storage.sync.get('token')
   if (token) {
     renderTako()
@@ -60,11 +68,10 @@ const renderTako = async () => {
 const renderTokenPrompt = async () => {
   const containerElement = await waitForElement('[data-hpc]')
   const rootElement = document.createElement('div')
+  rootElement.classList.add('tako')
   containerElement.prepend(rootElement)
   createRoot(rootElement).render(<TokenPrompt />)
 }
 
-if (isRepoRoot() || isRepoTree()) {
-  document.addEventListener('DOMContentLoaded', () => setTimeout(start, 200))
-  document.addEventListener('turbo:render', () => setTimeout(start, 200))
-}
+document.addEventListener('DOMContentLoaded', start)
+document.addEventListener('turbo:render', start)

--- a/src/content.tsx
+++ b/src/content.tsx
@@ -10,13 +10,14 @@ import { useStore } from './store'
 import { onElementRemoval, waitForElement } from './waitForElement'
 
 const start = async () => {
-  if (!isRepoRoot() || !isRepoTree()) {
+  if (!isRepoRoot() || !isRepoTree() || document.querySelector('.tako')) {
     return
   }
 
   onElementRemoval('.tako', () => {
     start()
   })
+
   const { token } = await storage.sync.get('token')
   if (token) {
     renderTako()

--- a/src/waitForElement.ts
+++ b/src/waitForElement.ts
@@ -31,3 +31,25 @@ export const waitForElement = (selector: string, timeout = 2_000) =>
       observer.disconnect()
     }, timeout)
   })
+
+export const onElementRemoval = async (
+  selector: string,
+  callback: () => void,
+) => {
+  const observer = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      for (const removedNode of mutation.removedNodes.values()) {
+        const element = removedNode as HTMLElement
+        if (
+          typeof element.matches === 'function' &&
+          element.matches(selector)
+        ) {
+          callback()
+          observer.disconnect()
+        }
+      }
+    }
+  })
+
+  observer.observe(document.body, { childList: true, subtree: true })
+}


### PR DESCRIPTION
GH may blow away our react root for any reason, usually because we mount before their Turbo stuff does its thing.

Instead of figuring out the intricacies of Turbo rendering, we just re-render Tako when it gets removed.