### PR TITLE
Defer removal of og file list until last moment

### DIFF
--- a/src/content.tsx
+++ b/src/content.tsx
@@ -37,7 +37,6 @@ const start = async () => {
 
 const renderTako = async (octokit: Octokit) => {
   const [sourceTreeElement] = await Promise.all([waitForElement('[data-hpc]')])
-  sourceTreeElement.classList.add('d-none')
 
   const containerElement = document.createElement('div')
   containerElement.classList.add('tako')
@@ -65,6 +64,7 @@ const renderTako = async (octokit: Octokit) => {
     sidebarElement?.classList.toggle('d-none', hasPreviewedFile)
   })
 
+  sourceTreeElement.classList.add('d-none')
   createRoot(containerElement).render(
     <TakoProvider client={octokit} repository={repository}>
       <Tako />


### PR DESCRIPTION
On my tests, sometimes it can get up to 300ms in between removing the original file tree and adding tako's one.

This delays the switcharoo right up until we add tako, to avoid computing stuff and having nothing displayed to the user in between stages.